### PR TITLE
Add missing ordering relationship between Exec['download'] and Package['al-agent']

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,9 +22,10 @@ class al_agents::install inherits al_agents {
   }
 
   package {'al-agent':
-    ensure     => installed,
-    name      => $al_agents::al_agent_service,
+    ensure   => installed,
+    name     => $al_agents::al_agent_service,
     provider => $provider,
-    source  => $package_path,
+    source   => $package_path,
+    require  => Exec['download'],
   }
 }


### PR DESCRIPTION
This commit fixes non-determinism between the following resources:
* Exec['download']
* Package['al-agent']

Package['al-agent'] requires Exec['download']